### PR TITLE
Update getx-stateful-getbuilder-page.template.ts

### DIFF
--- a/src/templates/getx-stateful-getbuilder-page.template.ts
+++ b/src/templates/getx-stateful-getbuilder-page.template.ts
@@ -82,7 +82,7 @@ class ${pascalCaseName}Page extends StatefulWidget {
   const ${pascalCaseName}Page({Key? key}) : super(key: key);
 
   @override
-  _${pascalCaseName}PageState createState() => _${pascalCaseName}PageState();
+  State<${pascalCaseName}Page> createState() => _${pascalCaseName}PageState();
 }
 
 class _${pascalCaseName}PageState extends State<${pascalCaseName}Page>


### PR DESCRIPTION
Avoid using private types in public APIs.
https://dart-lang.github.io/linter/lints/library_private_types_in_public_api.html 
避免在公共 API 中使用库私有类型。